### PR TITLE
Revert header to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,17 +6,13 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>Chat Assistant</title>
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme" title="Toggle light/dark theme">
                     <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -133,38 +133,18 @@ body {
 /* Header */
 header {
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     padding: 1.5rem 2rem;
     flex-shrink: 0;
 }
 
 .header-content {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     max-width: 1200px;
     margin: 0 auto;
 }
 
-.header-text {
-    flex: 1;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {


### PR DESCRIPTION
This PR reverts the header to a simpler design as requested in issue #2.

## Changes:
- Remove "Course Materials Assistant" header text
- Remove subtitle about asking questions
- Remove horizontal border below header
- Keep theme toggle functionality
- Update page title to "Chat Assistant"
- Adjust CSS layout for minimal header design

Closes #2

Generated with [Claude Code](https://claude.ai/code)